### PR TITLE
Add SampleLevel builtin function to Sabre.

### DIFF
--- a/std/std/std.sabre
+++ b/std/std/std.sabre
@@ -24,6 +24,30 @@ func texture_sample(:Texture2D, :Sampler, :vec2): vec4
 }
 func texture_sample(:Texture3D, :Sampler, :vec3): vec4
 
+@sample_func
+@hlsl_method
+@builtin {
+	glsl = "textureLod"
+	hlsl = "SampleLevel"
+}
+func texture_sample_level(:Texture1D, :Sampler, :float, :float): vec4
+
+@sample_func
+@hlsl_method
+@builtin {
+	glsl = "textureLod"
+	hlsl = "SampleLevel"
+}
+func texture_sample_level(:Texture2D, :Sampler, :vec2, :float): vec4
+
+@sample_func
+@hlsl_method
+@builtin {
+	glsl = "textureLod"
+	hlsl = "SampleLevel"
+}
+func texture_sample_level(:Texture3D, :Sampler, :vec3, :float): vec4
+
 @hlsl_method
 @builtin {
 	hlsl = "Append"


### PR DESCRIPTION
This PR adds support for texture sampling at a specific mip level builtin functions for HLSL and GLSL.