### PR TITLE
Add texture read/write access to Sabre.

### DIFF
--- a/sabre/include/sabre/Check.h
+++ b/sabre/include/sabre/Check.h
@@ -20,6 +20,7 @@ namespace sabre
 		mn::Buf<Scope*> scope_stack;
 		mn::Buf<Decl*> func_stack;
 		mn::Buf<Type*> expected_expr_type;
+		// TODO: Add uniform binding generator for RWTexture?
 		int uniform_binding_generator;
 		int texture_binding_generator;
 		int sampler_binding_generator;

--- a/sabre/include/sabre/Scope.h
+++ b/sabre/include/sabre/Scope.h
@@ -65,6 +65,7 @@ namespace sabre
 				Expr* value;
 
 				// used when a variable refers is a uniform
+				bool read_write_access;
 				int uniform_binding;
 				bool is_uniform;
 				bool uniform_binding_processed;

--- a/sabre/include/sabre/Unit.h
+++ b/sabre/include/sabre/Unit.h
@@ -52,6 +52,7 @@ namespace sabre
 	inline constexpr const char* KEYWORD_POINT = "point";
 	inline constexpr const char* KEYWORD_LINE = "line";
 	inline constexpr const char* KEYWORD_TRIANGLE = "triangle";
+	inline constexpr const char* KEYWORD_READ_WRITE = "read_write";
 
 	enum COMPILATION_STAGE
 	{

--- a/sabre/src/sabre/Check.cpp
+++ b/sabre/src/sabre/Check.cpp
@@ -370,7 +370,7 @@ namespace sabre
 				Expr* value = nullptr;
 				if (i < decl->const_decl.values.count)
 					value = decl->const_decl.values[i];
-				// add symbol twice, once in file scope an another one in package scope
+				// add symbol twice, once in file scope and another one in package scope
 				auto sym = symbol_const_new(self.unit->symbols_arena, name, decl, sign, value);
 				_typer_add_symbol(self, sym);
 				// search for the pipeline of that shader
@@ -3605,6 +3605,7 @@ namespace sabre
 		}
 	}
 
+	// TODO: Check this.
 	inline static void
 	_typer_assign_bindings(Typer& self, Entry_Point* entry, Symbol* sym)
 	{
@@ -3634,6 +3635,9 @@ namespace sabre
 		auto uniform_tag_it = mn::map_lookup(decl->tags.table, KEYWORD_UNIFORM);
 		if (sym->type->kind == Type::KIND_TEXTURE)
 		{
+			if(mn::map_lookup(decl->tags.table, KEYWORD_READ_WRITE))
+				sym->var_sym.read_write_access = true;
+
 			if (auto binding_it = mn::map_lookup(uniform_tag_it->value.args, KEYWORD_BINDING))
 			{
 				auto value_tkn = binding_it->value.value;
@@ -3791,7 +3795,7 @@ namespace sabre
 					auto entry = entry_point_new(sym, COMPILATION_MODE_PIXEL);
 					mn::buf_push(self.unit->entry_points, entry);
 				}
-				else if (auto tag_it = mn::map_lookup(decl->tags.table, KEYWORD_GEOMETRY))
+				else if (mn::map_lookup(decl->tags.table, KEYWORD_GEOMETRY))
 				{
 					auto entry = entry_point_new(sym, COMPILATION_MODE_GEOMETRY);
 					mn::buf_push(self.unit->entry_points, entry);

--- a/sabre/src/sabre/Check.cpp
+++ b/sabre/src/sabre/Check.cpp
@@ -3605,7 +3605,6 @@ namespace sabre
 		}
 	}
 
-	// TODO: Check this.
 	inline static void
 	_typer_assign_bindings(Typer& self, Entry_Point* entry, Symbol* sym)
 	{

--- a/sabre/src/sabre/HLSL.cpp
+++ b/sabre/src/sabre/HLSL.cpp
@@ -1740,7 +1740,39 @@ namespace sabre
 
 			if (sym->type->kind == Type::KIND_TEXTURE)
 			{
-				mn::print_to(self.out, "{}: register(t{})", _hlsl_write_field(self, sym->type, uniform_name), sym->var_sym.uniform_binding);
+				// TODO: Move this part to the _hlsl_write_field(...) function, while taking into account texture read/write access.
+				if (sym->var_sym.read_write_access)
+				{
+					mn::Str str = mn::str_tmp();
+					if (sym->type == type_texture1d)
+					{
+						str = mn::strf(str, "RWTexture1D<float4>");
+					}
+					else if (sym->type == type_texture2d)
+					{
+						str = mn::strf(str, "RWTexture2D<float4>");
+					}
+					else if (sym->type == type_texture3d)
+					{
+						str = mn::strf(str, "RWTexture3D<float4>");
+					}
+					else if (sym->type == type_texture_cube)
+					{
+						str = mn::strf(str, "RWTextureCube<float4>");
+					}
+					else
+					{
+						mn_unreachable();
+					}
+
+					if (mn::str_lit(uniform_name).count > 0)
+						str = mn::strf(str, " {}", _hlsl_name(self, uniform_name));
+					mn::print_to(self.out, "{}: register(t{})", str, sym->var_sym.uniform_binding);
+				}
+				else
+				{
+					mn::print_to(self.out, "{}: register(t{})", _hlsl_write_field(self, sym->type, uniform_name), sym->var_sym.uniform_binding);
+				}
 			}
 			else if (type_is_sampler(sym->type))
 			{

--- a/sabre/src/sabre/HLSL.cpp
+++ b/sabre/src/sabre/HLSL.cpp
@@ -1756,10 +1756,6 @@ namespace sabre
 					{
 						str = mn::strf(str, "RWTexture3D<float4>");
 					}
-					else if (sym->type == type_texture_cube)
-					{
-						str = mn::strf(str, "RWTextureCube<float4>");
-					}
 					else
 					{
 						mn_unreachable();
@@ -1767,7 +1763,8 @@ namespace sabre
 
 					if (mn::str_lit(uniform_name).count > 0)
 						str = mn::strf(str, " {}", _hlsl_name(self, uniform_name));
-					mn::print_to(self.out, "{}: register(t{})", str, sym->var_sym.uniform_binding);
+					// TODO: Take into account that RWTexture bindings should start after the framebuffer output attachment count.
+					mn::print_to(self.out, "{}: register(u{})", str, sym->var_sym.uniform_binding);
 				}
 				else
 				{

--- a/sabre/src/sabre/HLSL.cpp
+++ b/sabre/src/sabre/HLSL.cpp
@@ -1756,6 +1756,11 @@ namespace sabre
 					{
 						str = mn::strf(str, "RWTexture3D<float4>");
 					}
+					else if (sym->type == type_texture_cube)
+					{
+						// TODO: Report error message or just produce normal TextureCube?
+						//       There is no RWTextureCube equivelant.
+					}
 					else
 					{
 						mn_unreachable();

--- a/sabre/src/sabre/Unit.cpp
+++ b/sabre/src/sabre/Unit.cpp
@@ -762,6 +762,7 @@ namespace sabre
 		mn::set_insert(self->str_interner.strings, mn::str_lit(KEYWORD_POINT));
 		mn::set_insert(self->str_interner.strings, mn::str_lit(KEYWORD_LINE));
 		mn::set_insert(self->str_interner.strings, mn::str_lit(KEYWORD_TRIANGLE));
+		mn::set_insert(self->str_interner.strings, mn::str_lit(KEYWORD_READ_WRITE));
 
 		unit_add_package(self, self->root_package);
 


### PR DESCRIPTION
This PR adds read/write access to textures in Sabre and provides code gen for both GLSL/HLSL for now.