### PR TITLE
Fix compiler warnings on warning level 4 for msvc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,13 @@ option(SABRE_BUILD_TESTS       "Build sabre unit tests."                        
 option(SABRE_LOG_METRICS       "Measures and logs different performance metrics."                            ${MASTER_PROJECT})
 option(SABRE_INSTALL           "Generates the install target"                                                ${MASTER_PROJECT})
 
+# Treat all compiler warnings as errors and increase warning level.
+if(MSVC)
+    add_compile_options(-W4 -WX)
+else()
+    add_compile_options(-Wall -Wextra -pedantic -Werror)
+endif()
+
 # external dependencies
 include(CPM)
 CPMAddPackage(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,6 @@ option(SABRE_INSTALL           "Generates the install target"                   
 # Treat all compiler warnings as errors and increase warning level.
 if(MSVC)
     add_compile_options(-W4 -WX)
-else()
-    add_compile_options(-Wall -Wextra -pedantic -Werror)
 endif()
 
 # external dependencies

--- a/sabre/include/sabre/Type_Interner.h
+++ b/sabre/include/sabre/Type_Interner.h
@@ -832,7 +832,7 @@ namespace sabre
 				return t->struct_type.fields[index].type;
 			return nullptr;
 		case Type::KIND_ARRAY:
-			if (index < t->array.count)
+			if ((int64_t)index < t->array.count)
 				return t->array.base;
 			return nullptr;
 		case Type::KIND_ENUM:

--- a/sabre/src/sabre/AST_Printer.cpp
+++ b/sabre/src/sabre/AST_Printer.cpp
@@ -78,7 +78,7 @@ namespace sabre
 			{
 				_ast_printer_enter_scope(self);
 				{
-					for (auto [_, kv]: tag.args)
+					for (auto [__, kv]: tag.args)
 					{
 						_ast_printer_newline(self);
 						mn::print_to(self.out, "(key: '{}', value: ", kv.key.str);

--- a/sabre/src/sabre/Expr_Value.cpp
+++ b/sabre/src/sabre/Expr_Value.cpp
@@ -38,7 +38,7 @@ namespace sabre
 			else
 				return nullptr;
 		case Type::KIND_ARRAY:
-			if (index < type->array.count)
+			if ((int64_t)index < type->array.count)
 				return type->array.base;
 			else
 				return nullptr;
@@ -175,7 +175,7 @@ namespace sabre
 		int r = 0;
 		if (a.type == type_int && b.type == type_int)
 		{
-			r = a.as_int - b.as_int;
+			r = (int)(a.as_int - b.as_int);
 		}
 		else if (a.type == type_double && b.type == type_double)
 		{
@@ -188,7 +188,7 @@ namespace sabre
 		}
 		else if (a.type == type_int && b.type == type_double)
 		{
-			double a_double = a.as_int;
+			double a_double = (double)a.as_int;
 			if (a_double < b.as_double)
 				r = -1;
 			else if (a_double > b.as_double)
@@ -244,7 +244,7 @@ namespace sabre
 		}
 		else if (a.type == type_int && b.type == type_double)
 		{
-			double a_double = a.as_int;
+			double a_double = (double)a.as_int;
 			return expr_value_double(a_double + b.as_double);
 		}
 		else if (a.type == type_double && b.type == type_int)
@@ -271,7 +271,7 @@ namespace sabre
 		}
 		else if (a.type == type_int && b.type == type_double)
 		{
-			double a_double = a.as_int;
+			double a_double = (double)a.as_int;
 			return expr_value_double(a_double - b.as_double);
 		}
 		else if (a.type == type_double && b.type == type_int)
@@ -298,7 +298,7 @@ namespace sabre
 		}
 		else if (a.type == type_int && b.type == type_double)
 		{
-			double a_double = a.as_int;
+			double a_double = (double)a.as_int;
 			return expr_value_double(a_double * b.as_double);
 		}
 		else if (a.type == type_double && b.type == type_int)
@@ -325,7 +325,7 @@ namespace sabre
 		}
 		else if (a.type == type_int && b.type == type_double)
 		{
-			double a_double = a.as_int;
+			double a_double = (double)a.as_int;
 			return expr_value_double(a_double / b.as_double);
 		}
 		else if (a.type == type_double && b.type == type_int)
@@ -552,9 +552,9 @@ namespace sabre
 		else if (type_is_array(t))
 		{
 			auto res = expr_value_aggregate(arena, t);
-			for (size_t i = 0; i < t->array.count; ++i)
+			for (int64_t i = 0; i < t->array.count; ++i)
 			{
-				expr_value_aggregate_set(res, i, expr_value_zero(arena, t->array.base));
+				expr_value_aggregate_set(res, (size_t)i, expr_value_zero(arena, t->array.base));
 			}
 			return res;
 		}
@@ -606,11 +606,11 @@ namespace sabre
 		}
 		else if (a.type == type_int)
 		{
-			return mn::json::value_number_new(a.as_int);
+			return mn::json::value_number_new((float)a.as_int);
 		}
 		else if (a.type == type_double)
 		{
-			return mn::json::value_number_new(a.as_double);
+			return mn::json::value_number_new((float)a.as_double);
 		}
 		else if (type_is_vec(a.type))
 		{
@@ -627,9 +627,9 @@ namespace sabre
 		else if (type_is_array(a.type))
 		{
 			auto arr = mn::json::value_array_new();
-			for (size_t i = 0; i < a.type->array.count; ++i)
+			for (int64_t i = 0; i < a.type->array.count; ++i)
 			{
-				if (auto it = mn::map_lookup(a.as_aggregate, i))
+				if (auto it = mn::map_lookup(a.as_aggregate, (size_t)i))
 					mn::json::value_array_push(arr, expr_value_to_json(it->value));
 				else
 					mn::json::value_array_push(arr, expr_value_to_json(expr_value_zero(mn::memory::tmp(), a.type->array.base)));
@@ -659,7 +659,7 @@ namespace sabre
 		}
 		else if (type_is_enum(a.type))
 		{
-			return mn::json::value_number_new(a.as_int);
+			return mn::json::value_number_new((float)a.as_int);
 		}
 		else
 		{

--- a/sabre/src/sabre/Parse.cpp
+++ b/sabre/src/sabre/Parse.cpp
@@ -636,21 +636,21 @@ namespace sabre
 		auto expr = _parser_parse_expr_cmp(self);
 		while (true)
 		{
-			auto tkn = _parser_eat_kind(self, Tkn::KIND_LOGICAL_AND);
-			if (tkn)
+			auto tkn_next = _parser_eat_kind(self, Tkn::KIND_LOGICAL_AND);
+			if (tkn_next)
 			{
 				auto rhs = _parser_parse_expr_cmp(self);
 				if (rhs == nullptr)
 				{
 					Err err{};
-					err.loc = tkn.loc;
+					err.loc = tkn_next.loc;
 					err.msg = mn::strf("missing right handside");
 					unit_err(self.unit, err);
 					break;
 				}
-				expr = expr_binary_new(self.unit->ast_arena, expr, tkn, rhs);
-				expr->loc.pos = tkn.loc.pos;
-				expr->loc.rng = Rng{tkn.loc.rng.begin, _parser_last_token(self).loc.rng.end};
+				expr = expr_binary_new(self.unit->ast_arena, expr, tkn_next, rhs);
+				expr->loc.pos = tkn_next.loc.pos;
+				expr->loc.rng = Rng{tkn_next.loc.rng.begin, _parser_last_token(self).loc.rng.end};
 				expr->loc.file = self.unit;
 			}
 			else
@@ -675,19 +675,19 @@ namespace sabre
 		auto expr = _parser_parse_expr_and(self);
 		while (true)
 		{
-			auto tkn = _parser_eat_kind(self, Tkn::KIND_LOGICAL_OR);
-			if (tkn)
+			auto tkn_next = _parser_eat_kind(self, Tkn::KIND_LOGICAL_OR);
+			if (tkn_next)
 			{
 				auto rhs = _parser_parse_expr_and(self);
 				if (rhs == nullptr)
 				{
 					Err err{};
-					err.loc = tkn.loc;
+					err.loc = tkn_next.loc;
 					err.msg = mn::strf("missing right handside");
 					unit_err(self.unit, err);
 					break;
 				}
-				expr = expr_binary_new(self.unit->ast_arena, expr, tkn, rhs);
+				expr = expr_binary_new(self.unit->ast_arena, expr, tkn_next, rhs);
 			}
 			else
 			{
@@ -957,7 +957,7 @@ namespace sabre
 		// there should be a semicolon here if we don't find it we skip to it
 		if (accept_semicolon && expect_semicolon)
 		{
-			if (auto tkn = _parser_look(self); tkn.kind == Tkn::KIND_SEMICOLON)
+			if (_parser_look_kind(self, Tkn::KIND_SEMICOLON))
 			{
 				_parser_eat(self); // eat the semicolon
 			}
@@ -971,8 +971,8 @@ namespace sabre
 
 				while (true)
 				{
-					auto tkn = _parser_eat(self);
-					if (parser_eof(self) || tkn.kind == Tkn::KIND_SEMICOLON)
+					auto tkn_semicolon = _parser_eat(self);
+					if (parser_eof(self) || tkn_semicolon.kind == Tkn::KIND_SEMICOLON)
 						break;
 				}
 			}
@@ -1312,8 +1312,8 @@ namespace sabre
 		{
 			if (_parser_eat_kind(self, Tkn::KIND_KEYWORD_IF))
 			{
-				auto if_cond = parser_parse_expr(self);
-				auto if_body = _parser_parse_decl_group(self);
+				if_cond = parser_parse_expr(self);
+				if_body = _parser_parse_decl_group(self);
 				mn::buf_push(cond, if_cond);
 				mn::buf_push(body, if_body);
 			}

--- a/sabre/src/sabre/Reflect.cpp
+++ b/sabre/src/sabre/Reflect.cpp
@@ -18,7 +18,7 @@ namespace sabre
 		{
 			auto& arg = decl->func_decl.args[i];
 
-			for (const auto& name: arg.names)
+			for (size_t j = 0; j < arg.names.count; ++j)
 			{
 				auto arg_type = entry_type->as_func.sign.args.types[type_index++];
 				switch (arg_type->kind)
@@ -26,8 +26,8 @@ namespace sabre
 				case Type::KIND_STRUCT:
 				{
 					size_t field_index = 0;
-					auto decl = symbol_decl(arg_type->struct_type.symbol);
-					for (auto& field: decl->struct_decl.fields)
+					auto decl_struct = symbol_decl(arg_type->struct_type.symbol);
+					for (auto& field: decl_struct->struct_decl.fields)
 					{
 						for (auto name: field.names)
 						{

--- a/sabre/src/sabre/SPIRV.cpp
+++ b/sabre/src/sabre/SPIRV.cpp
@@ -172,7 +172,7 @@ namespace sabre
 		case Tkn::KIND_LITERAL_INTEGER:
 		{
 			auto type = _spirv_type_gen(self, expr->type);
-			return spirv::module_int_constant(self.out, type, expr->const_value.as_int);
+			return spirv::module_int_constant(self.out, type, (int)expr->const_value.as_int);
 		}
 		default:
 			mn_unreachable();

--- a/sabre/src/sabre/Type_Interner.cpp
+++ b/sabre/src/sabre/Type_Interner.cpp
@@ -12,7 +12,7 @@ namespace sabre
 		self.unaligned_size = size;
 		self.alignment = alignment;
 		self.vec.base = base;
-		self.vec.width = width;
+		self.vec.width = (int)width;
 		return self;
 	}
 
@@ -24,7 +24,7 @@ namespace sabre
 		self.unaligned_size = size;
 		self.alignment = alignment;
 		self.mat.base = base;
-		self.mat.width = width;
+		self.mat.width = (int)width;
 		return self;
 	}
 
@@ -469,7 +469,7 @@ namespace sabre
 	}
 
 	void
-	type_interner_complete_enum(Type_Interner* self, Type* type, mn::Buf<Enum_Field_Type> fields, mn::Map<const char*, size_t> fields_table)
+	type_interner_complete_enum([[maybe_unused]] Type_Interner* self, Type* type, mn::Buf<Enum_Field_Type> fields, mn::Map<const char*, size_t> fields_table)
 	{
 		mn_assert(type->kind == Type::KIND_COMPLETING);
 		type->kind = Type::KIND_ENUM;

--- a/sabre/src/sabre/Unit.cpp
+++ b/sabre/src/sabre/Unit.cpp
@@ -314,7 +314,7 @@ namespace sabre
 				mn::json::Value value{};
 				if (arg_value.value->const_value.type == type_int)
 				{
-					value = mn::json::value_number_new(arg_value.value->const_value.as_int);
+					value = mn::json::value_number_new((float)arg_value.value->const_value.as_int);
 				}
 				else if (arg_value.value->const_value.type == type_lit_string)
 				{
@@ -727,7 +727,7 @@ namespace sabre
 	}
 
 	Unit*
-	unit_from_file(const mn::Str& filepath, const mn::Str& entry, BACKEND_MODE backend)
+	unit_from_file(const mn::Str& filepath, [[maybe_unused]] const mn::Str& entry, BACKEND_MODE backend)
 	{
 		auto self = mn::alloc_zerod<Unit>();
 
@@ -868,7 +868,7 @@ namespace sabre
 	}
 
 	bool
-	unit_reflect(Unit* self, Entry_Point* entry)
+	unit_reflect([[maybe_unused]] Unit* self, Entry_Point* entry)
 	{
 		if (entry == nullptr)
 			return false;
@@ -918,10 +918,10 @@ namespace sabre
 				auto uniform_name = mn::json::value_string_new(mn::str_tmpf("{}.{}", symbol->package->name.str, symbol->name));
 				mn::json::value_object_insert(json_uniform, "name", uniform_name);
 			}
-			mn::json::value_object_insert(json_uniform, "binding", mn::json::value_number_new(binding));
+			mn::json::value_object_insert(json_uniform, "binding", mn::json::value_number_new((float)binding));
 			mn::json::value_object_insert(json_uniform, "type", mn::json::value_string_new(_type_to_reflect_json(symbol->type, false)));
 			mn::json::value_object_insert(json_uniform, "tags", _decl_tags_to_json(symbol_decl(symbol)));
-			mn::json::value_object_insert(json_uniform, "size", mn::json::value_number_new(symbol->type->unaligned_size));
+			mn::json::value_object_insert(json_uniform, "size", mn::json::value_number_new((float)symbol->type->unaligned_size));
 
 			mn::json::value_array_push(json_uniforms, json_uniform);
 
@@ -944,7 +944,7 @@ namespace sabre
 				auto uniform_name = mn::json::value_string_new(mn::str_tmpf("{}.{}", symbol->package->name.str, symbol->name));
 				mn::json::value_object_insert(json_texture, "name", uniform_name);
 			}
-			mn::json::value_object_insert(json_texture, "binding", mn::json::value_number_new(binding));
+			mn::json::value_object_insert(json_texture, "binding", mn::json::value_number_new((float)binding));
 			mn::json::value_object_insert(json_texture, "type", mn::json::value_string_new(_type_to_reflect_json(symbol->type, false)));
 			mn::json::value_object_insert(json_texture, "tags", _decl_tags_to_json(symbol_decl(symbol)));
 			mn::json::value_array_push(json_textures, json_texture);
@@ -959,9 +959,9 @@ namespace sabre
 			mn::json::value_object_insert(json_type, "name", mn::json::value_string_new(_type_to_reflect_json(type, false)));
 			mn::json::value_object_insert(json_type, "raw_name", mn::json::value_string_new(_type_to_reflect_json(type, true)));
 			mn::json::value_object_insert(json_type, "kind", mn::json::value_string_new(_type_kind(type)));
-			mn::json::value_object_insert(json_type, "aligned_size", mn::json::value_number_new(_type_aligned_size(type)));
-			mn::json::value_object_insert(json_type, "unaligned_size", mn::json::value_number_new(type->unaligned_size));
-			mn::json::value_object_insert(json_type, "alignment", mn::json::value_number_new(type->alignment));
+			mn::json::value_object_insert(json_type, "aligned_size", mn::json::value_number_new((float)_type_aligned_size(type)));
+			mn::json::value_object_insert(json_type, "unaligned_size", mn::json::value_number_new((float)type->unaligned_size));
+			mn::json::value_object_insert(json_type, "alignment", mn::json::value_number_new((float)type->alignment));
 
 			mn::json::Value tags{};
 			if (auto symbol = type_symbol(type))
@@ -984,7 +984,7 @@ namespace sabre
 					auto json_field = mn::json::value_object_new();
 					mn::json::value_object_insert(json_field, "name", mn::json::value_string_new(field.name.str));
 					mn::json::value_object_insert(json_field, "type", mn::json::value_string_new(_type_to_reflect_json(field.type, false)));
-					mn::json::value_object_insert(json_field, "offset", mn::json::value_number_new(field.offset));
+					mn::json::value_object_insert(json_field, "offset", mn::json::value_number_new((float)field.offset));
 					mn::json::value_array_push(json_fields, json_field);
 				}
 				mn::json::value_object_insert(json_type, "fields", json_fields);
@@ -993,8 +993,8 @@ namespace sabre
 			case Type::KIND_ARRAY:
 			{
 				mn::json::value_object_insert(json_type, "array_base_type", mn::json::value_string_new(_type_to_reflect_json(type->array.base, false)));
-				mn::json::value_object_insert(json_type, "array_count", mn::json::value_number_new(type->array.count));
-				mn::json::value_object_insert(json_type, "array_stride", mn::json::value_number_new(type->unaligned_size / type->array.count));
+				mn::json::value_object_insert(json_type, "array_count", mn::json::value_number_new((float)type->array.count));
+				mn::json::value_object_insert(json_type, "array_stride", mn::json::value_number_new((float)(type->unaligned_size / type->array.count)));
 				break;
 			}
 			default:

--- a/unittest/data/stmt/var_missing_semicolon.sabre.out
+++ b/unittest/data/stmt/var_missing_semicolon.sabre.out
@@ -1,1 +1,3 @@
-Error[var_missing_semicolon.sabre]: Expected a semicolon at the end of the statement
+>> var x = 12
+>> ^^^       
+Error[var_missing_semicolon.sabre:1:0]: Expected a semicolon at the end of the statement


### PR DESCRIPTION
This is a pass throughout the source files to fix compile warnings with flags `-W4 -WX` on `msvc` compiler.

It also corrects the output of parsing error generated by forgetting to add a semicolon to the end of a statement.